### PR TITLE
[WIP] clean/speed up graph_data

### DIFF
--- a/code/graph_data.py
+++ b/code/graph_data.py
@@ -7,6 +7,11 @@ import numpy as np
 import pandas as pd
 from pyjet import cluster,DTYPE_PTEPM
 import glob
+import multiprocessing
+
+def process_func(args):
+    self, raw_path, k = args
+    return self.process_one_chunk(raw_path, k)
 
 class GraphDataset(Dataset):
     """
@@ -19,15 +24,18 @@ class GraphDataset(Dataset):
     full: whether or not to read/process in the full file
     n_events: how many events to process
     """
-    def __init__(self, root, transform=None, pre_transform=None, start=0, stop=-1, 
-                 n_particles=-1, bb=0, full=False, n_events=10000):
+    def __init__(self, root, transform=None, pre_transform=None, start=0, stop=-1,
+                 n_particles=-1, bb=0, full=False, n_events=10000, n_jobs=4):
         self.start = start
         self.stop = stop
         self.n_particles = n_particles
         self.bb = bb
         self.full = full
         self.n_events = 1000000 if full else n_events
-        super(GraphDataset, self).__init__(root, transform, pre_transform) 
+        self.n_jobs = n_jobs
+        self.chunk_size = self.n_events // self.n_jobs
+        self.file_string = ['data_{}_{}.pt', 'data_bb1_{}_{}.pt', 'data_bb2_{}_{}.pt', 'data_bb3_{}_{}.pt']
+        super(GraphDataset, self).__init__(root, transform, pre_transform)
 
 
     @property
@@ -40,21 +48,8 @@ class GraphDataset(Dataset):
 
     @property
     def processed_file_names(self):
-        # possible file formats of boxes to read with regex for glob
-        file_string = ['data_[0-9]*.pt', 'data_bb1_[0-9]*.pt', 'data_bb2_[0-9]*.pt', 'data_bb3_[0-9]*.pt']
-        
-        if self.full == True: # return all processed files for this box
-            files = [osp.basename(x) for x in glob.glob(osp.join(self.processed_dir, file_string[self.bb]))]
-            return files
-        
-        # possible file formats for fixed njets formatting
-        file_string = ['data_{}.pt', 'data_bb1_{}.pt', 'data_bb2_{}.pt', 'data_bb3_{}.pt']
-        if self.stop!=-1:
-            njets = self.stop-self.start
-            return [file_string[self.bb].format(i) for i in range(self.start,self.stop)]
-        else:
-            njets = 24043
-            return [file_string[self.bb].format(i) for i in range(njets)]
+        proc_list = glob.glob(osp.join(self.processed_dir, 'data*.pt'))
+        return sorted([l.replace(self.processed_dir, '.') for l in proc_list])
 
     def __len__(self):
         return len(self.processed_file_names)
@@ -63,109 +58,92 @@ class GraphDataset(Dataset):
         # Download to `self.raw_dir`.
         pass
 
+    def process_one_chunk(self, raw_path, k):
+        df = pd.read_hdf(raw_path, start = k * self.chunk_size, stop = (k + 1) * self.chunk_size)
+        all_events = df.values
+        rows = all_events.shape[0]
+        cols = all_events.shape[1]
+
+        for i in range(rows):
+            event_idx = k*self.chunk_size + i
+            ijet = 0
+            if event_idx % 100 == 0:
+                print('Processing event {}'.format(event_idx))
+            pseudojets_input = np.zeros(len([x for x in all_events[i][::3] if x > 0]), dtype=DTYPE_PTEPM)
+            for j in range(cols // 3):
+                if (all_events[i][j*3]>0):
+                    pseudojets_input[j]['pT'] = all_events[i][j*3]
+                    pseudojets_input[j]['eta'] = all_events[i][j*3+1]
+                    pseudojets_input[j]['phi'] = all_events[i][j*3+2]
+                pass
+
+            # cluster jets from the particles in one observation
+            sequence = cluster(pseudojets_input, R=1.0, p=-1)
+            jets = sequence.inclusive_jets()
+            for jet in jets: # for each jet get (px, py, pz, e)
+                if jet.pt < 200: continue
+                if self.n_particles > -1:
+                    n_particles = self.n_particles
+                else:
+                    n_particles = len(jet)
+                particles = np.zeros((n_particles, 8))
+
+                # store all the particles of this jet
+                for p, part in enumerate(jet):
+                    if n_particles > -1 and p >= n_particles: break
+                    # save two representations: px, py, pz, e, and pt, eta, phi, mass
+                    particles[p,:] = np.array([part.px,
+                                               part.py,
+                                               part.pz,
+                                               part.e,
+                                               part.pt,
+                                               part.eta,
+                                               part.phi,
+                                               part.mass])
+                n_particles = len(jet)
+                pairs = np.stack([[m, n] for (m, n) in itertools.product(range(n_particles),range(n_particles)) if m!=n])
+                # save [deta, dphi] as edge attributes (may not be used depending on model)
+                eta0s = particles[pairs[:,0],6]
+                eta1s = particles[pairs[:,1],6]
+                phi0s = particles[pairs[:,0],7]
+                phi1s = particles[pairs[:,1],7]
+                detas = np.abs(eta0s - eta1s)
+                dphis = (phi0s - phi1s + np.pi) % (2 * np.pi) - np.pi
+                edge_attr = np.stack([detas,dphis],axis=1)
+                edge_attr = torch.tensor(edge_attr, dtype=torch.float)
+                edge_index = torch.tensor(pairs, dtype=torch.long)
+                edge_index=edge_index.t().contiguous()
+                # save [px, py, pz, e] of particles as node attributes and target
+                x = torch.tensor(particles[:,:4], dtype=torch.float)
+                y = torch.tensor(particles[:,:4], dtype=torch.float)
+                # save [n_particles, mass, px, py, pz, e] of the jet as global attributes
+                # (may not be used depending on model)
+                u = torch.tensor([n_particles, jet.mass, jet.px, jet.py, jet.pz, jet.e], dtype=torch.float)
+                data = Data(x=x, edge_index=edge_index, y=y, edge_attr=edge_attr)
+                data.u = u
+                if self.pre_filter is not None and not self.pre_filter(data):
+                    continue
+                if self.pre_transform is not None:
+                    data = self.pre_transform(data)
+
+                # save data in format (particle_data, event_of_jet, mass_of_jet, px, py, pz, e)
+                torch.save((data, event_idx, jet.mass, jet.px, jet.py, jet.pz, jet.e),
+                           osp.join(self.processed_dir, self.file_string[self.bb].format(event_idx, ijet)))
+                ijet += 1
 
     def process(self):
-        
         # only do 10000 events for background, process full blackboxes
-        total_size = self.n_events
-        chunk_size = self.n_events // 10
-
         for raw_path in self.raw_paths:
-            event_idx = 0
-            ijet = 0
-            for k in range(total_size // chunk_size - 1):
-                
-                data = []
-                nonzero_particles = []
-                event_indices = []
-                masses = []
-                px = []
-                py = []
-                pz = []
-                e = []
-        
-                df = pd.read_hdf(raw_path, start = k * chunk_size, stop = (k + 1) * chunk_size)
-                all_events = df.values
-                rows = all_events.shape[0]
-                cols = all_events.shape[1]
-            
-                for i in range(rows):
-                    pseudojets_input = np.zeros(len([x for x in all_events[i][::3] if x > 0]), dtype=DTYPE_PTEPM)
-                    for j in range(cols // 3):
-                        if (all_events[i][j*3]>0):
-                            pseudojets_input[j]['pT'] = all_events[i][j*3]
-                            pseudojets_input[j]['eta'] = all_events[i][j*3+1]
-                            pseudojets_input[j]['phi'] = all_events[i][j*3+2]
-                        pass
-
-                    # cluster jets from the particles in one observation
-                    sequence = cluster(pseudojets_input, R=1.0, p=-1)
-                    jets = sequence.inclusive_jets()
-                    for jet in jets: # for each jet get (px, py, pz, e)
-                        if jet.pt < 200: continue
-                        if self.n_particles > -1: 
-                            n_particles = self.n_particles
-                        else:
-                            n_particles = len(jet)
-                        particles = np.zeros((n_particles, 8))
-
-                        # store all the particles of this jet
-                        for p, part in enumerate(jet):
-                            if n_particles > -1 and p >= n_particles: break
-                            # save two representations: px, py, pz, e, and pt, eta, phi, mass
-                            particles[p,:] = np.array([part.px,
-                                                       part.py,
-                                                       part.pz,
-                                                       part.e,
-                                                       part.pt,
-                                                       part.eta,
-                                                       part.phi,
-                                                       part.mass])
-                        data.append(particles)
-                        nonzero_particles.append(len(jet))
-                        event_indices.append(event_idx)
-                        masses.append(jet.mass)
-                        px.append(jet.px)
-                        py.append(jet.py)
-                        pz.append(jet.pz)
-                        e.append(jet.e)
-                    event_idx += 1
-
-                file_string = ['data_{}.pt', 'data_bb1_{}.pt', 'data_bb2_{}.pt', 'data_bb3_{}.pt']
-                for data_idx, d in enumerate(data):
-                    n_particles = nonzero_particles[data_idx]
-                    pairs = np.stack([[i, j] for (i, j) in itertools.product(range(n_particles),range(n_particles)) if i!=j])
-                    # save [deta, dphi] as edge attributes (may not be used depending on model)
-                    eta0s = d[pairs[:,0],6]
-                    eta1s = d[pairs[:,1],6]
-                    phi0s = d[pairs[:,0],7]
-                    phi1s = d[pairs[:,1],7]
-                    detas = np.abs(eta0s - eta1s)
-                    dphis = (phi0s - phi1s + np.pi) % (2 * np.pi) - np.pi
-                    edge_attr = np.stack([detas,dphis],axis=1)
-                    edge_attr = torch.tensor(edge_attr, dtype=torch.float)
-                    edge_index = torch.tensor(pairs, dtype=torch.long)
-                    edge_index=edge_index.t().contiguous()
-                    # save [px, py, pz, e] as node attributes and target
-                    x = torch.tensor(d[:,:4], dtype=torch.float)
-                    y = torch.tensor(d[:,:4], dtype=torch.float)
-                    # save [n_particles, mass, px, py, pz, e] of the jet as global attributes (may not be used depending on model)
-                    u = torch.tensor([n_particles, masses[data_idx], px[data_idx], py[data_idx], pz[data_idx], e[data_idx]], dtype=torch.float)
-                    data = Data(x=x, edge_index=edge_index, y=y, edge_attr=edge_attr)
-                    data.u = u
-                    if self.pre_filter is not None and not self.pre_filter(data):
-                        continue
-                    if self.pre_transform is not None:
-                        data = self.pre_transform(data)
-
-                    # save data in format (jet_Data, event_of_jet, mass_of_jet, px, py, pz, e)
-                    torch.save((data, event_indices[data_idx],
-                                masses[data_idx], px[data_idx],
-                                py[data_idx], pz[data_idx],
-                                e[data_idx]), osp.join(self.processed_dir, file_string[self.bb].format(ijet)))
-                    ijet += 1
+            pars = []
+            for k in range(self.n_events // self.chunk_size):
+                # to do it sequentially
+                #self.process_one_chunk(raw_path, k)
+                # to do it with multiprocessing
+                pars += [(self, raw_path, k)]
+            pool = multiprocessing.Pool(self.n_jobs)
+            pool.map(process_func, pars)
 
     def get(self, idx):
-        file_string = ['data_{}.pt', 'data_bb1_{}.pt', 'data_bb2_{}.pt', 'data_bb3_{}.pt']
-        data = torch.load(osp.join(self.processed_dir, file_string[self.bb].format(idx)))
+        p = osp.join(self.processed_dir, processed_file_names[idx])
+        data = torch.load(p)
         return data

--- a/code/graph_data.py
+++ b/code/graph_data.py
@@ -75,7 +75,7 @@ class GraphDataset(Dataset):
             sequence = cluster(pseudojets_input, R=1.0, p=-1)
             jets = sequence.inclusive_jets()
             for jet in jets: # for each jet get (px, py, pz, e)
-                if jet.pt < 200: continue
+                if jet.pt < 200 and len(jet)<=1: continue
                 if self.n_particles > -1:
                     n_particles = self.n_particles
                 else:
@@ -94,7 +94,10 @@ class GraphDataset(Dataset):
                                                part.eta,
                                                part.phi,
                                                part.mass])
-                n_particles = len(jet)
+                if self.n_particles>-1:
+                    n_particles = min(len(jet),self.n_particles)
+                else:
+                    n_particles = len(jet)
                 pairs = np.stack([[m, n] for (m, n) in itertools.product(range(n_particles),range(n_particles)) if m!=n])
                 # save [deta, dphi] as edge attributes (may not be used depending on model)
                 eta0s = particles[pairs[:,0],6]

--- a/code/graph_data.py
+++ b/code/graph_data.py
@@ -98,6 +98,7 @@ class GraphDataset(Dataset):
                     n_particles = min(len(jet),self.n_particles)
                 else:
                     n_particles = len(jet)
+                print(event_idx, ijet, n_particles, jet.pt, len(jet), self.n_particles, particles.shape[0])
                 pairs = np.stack([[m, n] for (m, n) in itertools.product(range(n_particles),range(n_particles)) if m!=n])
                 # save [deta, dphi] as edge attributes (may not be used depending on model)
                 eta0s = particles[pairs[:,0],6]

--- a/code/graph_data.py
+++ b/code/graph_data.py
@@ -75,7 +75,7 @@ class GraphDataset(Dataset):
             sequence = cluster(pseudojets_input, R=1.0, p=-1)
             jets = sequence.inclusive_jets()
             for jet in jets: # for each jet get (px, py, pz, e)
-                if jet.pt < 200 and len(jet)<=1: continue
+                if jet.pt < 200 or len(jet)<=1: continue
                 if self.n_particles > -1:
                     n_particles = self.n_particles
                 else:


### PR DESCRIPTION
### Changes to clean up and speed up `graph_data.py`
- clean up jet/particle/saving loop so we save `.pt` files immediately (no waiting for the first clustering loop to finish)
- `processed_file_names` function now just reads already processed files (so you should remove files from this directory if you actually want to reprocess)
- output saved files now have two indices (one is the global event index and the second is the jet index per event). For example `data_458_0.pt` means this is the 1st jet in the 459th event (indexing starts from 0)
- using multiprocessing to run 4 processes (seems to be ok with the standard 2 CPU pods... could probably use more processes in jobs with more CPUs)
- apparently multiprocessing is not super easy to use within a jupyter notebook (https://medium.com/@grvsinghal/speed-up-your-python-code-using-multiprocessing-on-windows-and-jupyter-or-ipython-2714b49d6fac) so what we can do is just pre-process by running `graph_data.py` as a script then load the dataset as we have been doing already in jupyter
- example usage:
``` 
python graph_data.py --dataset /anomalyvol/data/gnn_node_global/ --n-events 100000 --n-particles -1 --bb 0
```
- for some reason, it stalls when I try to run it with the full dataset although it seems totally fine with the example above (100k events)... not sure what's going on
